### PR TITLE
Handle ClassCastException

### DIFF
--- a/src/Eclipse-IDE/org.robotframework.ide.eclipse.main.plugin/src/org/robotframework/ide/eclipse/main/plugin/tableeditor/source/SuiteSourceEditor.java
+++ b/src/Eclipse-IDE/org.robotframework.ide.eclipse.main.plugin/src/org/robotframework/ide/eclipse/main/plugin/tableeditor/source/SuiteSourceEditor.java
@@ -211,10 +211,12 @@ public class SuiteSourceEditor extends TextEditor {
             final int columnNumber = caretPosition - document.getLineOffset(lineNumber) + 1;
             lineNumber++;
 
-            final StatusLineContributionItem find = (StatusLineContributionItem) getEditorSite().getActionBars()
-                    .getStatusLineManager()
-                    .find(ITextEditorActionConstants.STATUS_CATEGORY_INPUT_POSITION);
-            find.setText(lineNumber + ":" + columnNumber);
+            IContributionItem find = getEditorSite().getActionBars()
+                .getStatusLineManager()
+                .find(ITextEditorActionConstants.STATUS_CATEGORY_INPUT_POSITION);
+            if (find instanceof StatusLineContributionItem) {
+                find.setText(lineNumber + ":" + columnNumber);
+            }
         } catch (final BadLocationException e) {
             RedPlugin.logError("Unable to get position in source editor in order to update status bar", e);
         }
@@ -223,11 +225,13 @@ public class SuiteSourceEditor extends TextEditor {
     private void updateLineDelimitersStatus() {
         final IDocument document = getDocument();
 
-        final StatusLineContributionItem find = (StatusLineContributionItem) getEditorSite().getActionBars()
+        IContributionItem find = getEditorSite().getActionBars()
                 .getStatusLineManager()
-                .find(RobotFormEditorActionBarContributor.DELIMITERS_INFO_ID);
-        final String delimiter = DocumentUtilities.getDelimiter(document);
-        find.setText("\r\n".equals(delimiter) ? "CR+LF" : "LF");
+                .find(ITextEditorActionConstants.STATUS_CATEGORY_INPUT_POSITION);
+        if (find instanceof StatusLineContributionItem) {
+            final String delimiter = DocumentUtilities.getDelimiter(document);
+            find.setText("\r\n".equals(delimiter) ? "CR+LF" : "LF");
+        }
     }
 
     private void installBreakpointTogglingOnDoubleClick() {


### PR DESCRIPTION
java.lang.ClassCastException: org.eclipse.jface.action.SubContributionItem cannot be cast to org.eclipse.ui.texteditor.StatusLineContributionItemjava.lang.ClassCastException: org.eclipse.jface.action.SubContributionItem cannot be cast to org.eclipse.ui.texteditor.StatusLineContributionItem at org.robotframework.ide.eclipse.main.plugin.tableeditor.source.SuiteSourceEditor.updateLineLocationStatusBar(SuiteSourceEditor.java:207) at org.robotframework.ide.eclipse.main.plugin.tableeditor.source.SuiteSourceEditor.lambda$2(SuiteSourceEditor.java:195) at org.eclipse.swt.custom.StyledTextListener.handleEvent(StyledTextListener.java:97) at org.eclipse.swt.widgets.EventTable.sendEvent(EventTable.java:86) at org.eclipse.swt.widgets.Display.sendEvent(Display.java:4428) at org.eclipse.swt.widgets.Widget.sendEvent(Widget.java:1079) at org.eclipse.swt.widgets.Widget.sendEvent(Widget.java:1103) at org.eclipse.swt.widgets.Widget.sendEvent(Widget.java:1088) at org.eclipse.swt.widgets.Widget.notifyListeners(Widget.java:802) at org.eclipse.swt.custom.StyledText.setCaretOffset(StyledText.java:8688) at org.eclipse.swt.custom.StyledText.doMouseLocationChange(StyledText.java:2881) at org.eclipse.swt.custom.StyledText.handleMouseDown(StyledText.java:6107) at org.eclipse.swt.custom.StyledText.lambda$1(StyledText.java:5735) at org.eclipse.swt.widgets.EventTable.sendEvent(EventTable.java:86) at org.eclipse.swt.widgets.Display.sendEvent(Display.java:4428) at org.eclipse.swt.widgets.Widget.sendEvent(Widget.java:1079) at org.eclipse.swt.widgets.Display.runDeferredEvents(Display.java:4238) at org.eclipse.swt.widgets.Display.readAndDispatch(Display.java:3817) at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine$5.run(PartRenderingEngine.java:1150) at org.eclipse.core.databinding.observable.Realm.runWithDefault(Realm.java:336) at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine.run(PartRenderingEngine.java:1039) at org.eclipse.e4.ui.internal.workbench.E4Workbench.createAndRunUI(E4Workbench.java:153) at org.eclipse.ui.internal.Workbench.lambda$3(Workbench.java:680) at org.eclipse.core.databinding.observable.Realm.runWithDefault(Realm.java:336) at org.eclipse.ui.internal.Workbench.createAndRunWorkbench(Workbench.java:594) at org.eclipse.ui.PlatformUI.createAndRunWorkbench(PlatformUI.java:148) at com.fnfr.svt.rcp.Application.runWorkbench(Application.java:231) at com.fnfr.svt.rcp.Application.start(Application.java:190) at org.eclipse.equinox.internal.app.EclipseAppHandle.run(EclipseAppHandle.java:196) at org.eclipse.core.runtime.internal.adaptor.EclipseAppLauncher.runApplication(EclipseAppLauncher.java:134) at org.eclipse.core.runtime.internal.adaptor.EclipseAppLauncher.start(EclipseAppLauncher.java:104) at org.eclipse.core.runtime.adaptor.EclipseStarter.run(EclipseStarter.java:388) at org.eclipse.core.runtime.adaptor.EclipseStarter.run(EclipseStarter.java:243) at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method) at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) at java.lang.reflect.Method.invoke(Method.java:498) at org.eclipse.equinox.launcher.Main.invokeFramework(Main.java:653) at org.eclipse.equinox.launcher.Main.basicRun(Main.java:590) at org.eclipse.equinox.launcher.Main.run(Main.java:1499)