### PR TITLE
Avoid RF4.0 error:"Status.NOT RUN " when test fails

### DIFF
--- a/src/RobotFrameworkCore/org.robotframework.ide.core-functions/src/main/java/org/rf/ide/core/execution/agent/Status.java
+++ b/src/RobotFrameworkCore/org.robotframework.ide.core-functions/src/main/java/org/rf/ide/core/execution/agent/Status.java
@@ -9,5 +9,6 @@ package org.rf.ide.core.execution.agent;
 public enum Status {
     PASS,
     FAIL,
-    RUNNING
+    RUNNING,
+    NOT_RUN
 }

--- a/src/RobotFrameworkCore/org.robotframework.ide.core-functions/src/main/java/org/rf/ide/core/execution/agent/event/KeywordEndedEvent.java
+++ b/src/RobotFrameworkCore/org.robotframework.ide.core-functions/src/main/java/org/rf/ide/core/execution/agent/event/KeywordEndedEvent.java
@@ -33,7 +33,7 @@ public final class KeywordEndedEvent {
             throw new IllegalArgumentException(
                     "Keyword ended event should have name of keyword and library, keyword type and status");
         }
-        return new KeywordEndedEvent(libOrResourceName, keywordName, keywordType, Status.valueOf(status));
+        return new KeywordEndedEvent(libOrResourceName, keywordName, keywordType, Status.valueOf(status.replace(" ", "_")));
     }
 
     private final String libOrResourceName;


### PR DESCRIPTION
avoid RF4.0 error:

`An internal error occurred during: "Agent connection server".
No enum constant org.rf.ide.core.execution.agent.Status.NOT RUN`
when test fails.